### PR TITLE
Fixed text selection code in the case of number type

### DIFF
--- a/src/RIENumber.js
+++ b/src/RIENumber.js
@@ -15,6 +15,11 @@ export default class RIENumber extends RIEStatefulBase {
         return !isNaN(value) && isFinite(value) && value.length > 0;
     };
 
+    selectInputText = (element) => {
+        // element.setSelectionRange won't work for an input of type "number"
+        setTimeout(function() { element.select(); }, 10);
+    }
+
     renderNormalComponent = () => {
         return <span
             tabIndex="0"


### PR DESCRIPTION
Love this library and I'm finding it really useful, but I noticed there were a lot of errors in my console from the number editor. They are happening on your demo page too. Turns out the setSelectionRange() method won't work if the input type is "number", so I've overridden it with an alternative implementation in that case.

(As an aside I had to get rid of a duplicate export statement from the very bottom of src/RIEBase.js in order to build and test the code locally - I haven't included that though as it's not part of this change.)