### PR TITLE
added onFinish and onStart hooks

### DIFF
--- a/src/RIEBase.js
+++ b/src/RIEBase.js
@@ -29,7 +29,9 @@ export default class RIEBase extends React.Component {
         classEditing: React.PropTypes.string,
         classDisabled: React.PropTypes.string,
         classInvalid: React.PropTypes.string,
-        className: React.PropTypes.string
+        className: React.PropTypes.string,
+        onFinish: React.PropTypes.func,
+        onStart: React.PropTypes.func
     };
 
     doValidations = (value) => {

--- a/src/RIEStatefulBase.js
+++ b/src/RIEStatefulBase.js
@@ -8,10 +8,12 @@ export default class RIEStatefulBase extends RIEBase {
     }
 
     startEditing = () => {
+        this.props.onStart ? this.props.onStart() : null;
         this.setState({editing: true});
     };
 
     finishEditing = () => {
+        this.props.onFinish ? this.props.onFinish() : null;
         let newValue = ReactDOM.findDOMNode(this.refs.input).value;
         this.doValidations(newValue);
         if(!this.state.invalid && this.props.value !== newValue) {


### PR DESCRIPTION
I needed a way of calling functions at the start and end of the editing process. 
I added two optional props called `onStart` and `onFinish`
If passed, they respectively execute at the top of the `startEditing` and `finishEditing` methods of RIEStatefulBase.

Would love to know if there is a more appropriate way of accomplishing this.
cheers,