### PR TITLE
Add validate to tags control

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -20445,7 +20445,7 @@
 	        var _this2 = _possibleConstructorReturn(this, (RIETags.__proto__ || Object.getPrototypeOf(RIETags)).call(this, props));
 
 	        _this2.addTag = function (tag) {
-	            if ([].concat(_toConsumableArray(_this2.props.value)).length < (_this2.props.maxTags || 65535)) {
+	            if (_this2.doValidations(tag) && [].concat(_toConsumableArray(_this2.props.value)).length < (_this2.props.maxTags || 65535)) {
 	                _this2.commit(_this2.props.value.add(tag));
 	            }
 	        };

--- a/src/RIETags.js
+++ b/src/RIETags.js
@@ -42,7 +42,7 @@ export default class RIETags extends RIEStatefulBase {
     };
 
     addTag = (tag) => {
-        if([...this.props.value].length < (this.props.maxTags || 65535)) {
+        if(this.doValidations(tag) && [...this.props.value].length < (this.props.maxTags || 65535)) {
             this.commit(this.props.value.add(tag));
         }
     };


### PR DESCRIPTION
If the caller specifies a validate property to a RIETags component, call it before adding the tag, and don't add it if validation fails