### PR TITLE
Prevent transition to editing state from loading state on click

### DIFF
--- a/src/RIEStatefulBase.js
+++ b/src/RIEStatefulBase.js
@@ -93,6 +93,7 @@ export default class RIEStatefulBase extends RIEBase {
 
     elementClick = (event) => {
         debug(`elementClick(${event})`)
+        if (this.state.loading) return;
         this.startEditing();
         event.target.element.focus();
     };


### PR DESCRIPTION
Bug:
1. start edit, change value, enter value
2. loading state appeared
3. click over `<span>` (in my case `<span>` appears with `.loading:after{content: 'loading...'}`)
4. editing component appears until loading pending

expected:
4. no reaction