### PR TITLE
Dynamically grow/shrink dimensions of RIEInput during editing

### DIFF
--- a/src/RIEStatefulBase.js
+++ b/src/RIEStatefulBase.js
@@ -44,6 +44,20 @@ export default class RIEStatefulBase extends RIEBase {
         else if (event.keyCode === 27) { this.cancelEditing() }     // Escape
     };
 
+    keyUp = () => {
+        debug('keyUp')
+        this.resizeInput(this.refs.input);
+    };
+
+    resizeInput = (input) => {
+        if (!input.startW) { input.startW = input.offsetWidth; }
+        const style = input.style;
+        style.width = 0;                        // recalculate from 0, in case characters are deleted
+        let desiredW = input.scrollWidth;  
+        desiredW += input.offsetHeight;         // pad to reduce jerkyness when typing
+        style.width = Math.max(desiredW, input.startW) + 'px';
+    }
+
     textChanged = (event) => {
         debug('textChanged(${event.target.value})')
         this.doValidations(event.target.value.trim());
@@ -56,6 +70,7 @@ export default class RIEStatefulBase extends RIEBase {
         if (this.state.editing && !prevState.editing) {
             debug('entering edit mode')
             inputElem.focus();
+            this.resizeInput(inputElem);
             this.selectInputText(inputElem);
         } else if (this.state.editing && prevProps.text != this.props.text) {
             debug('not editing && text not equal previous props -- finishing editing')
@@ -73,6 +88,7 @@ export default class RIEStatefulBase extends RIEBase {
             onBlur={this.elementBlur}
             ref="input"
             onKeyDown={this.keyDown}
+            onKeyUp={this.keyUp}
             {...this.props.editProps} />;
     };
 


### PR DESCRIPTION
Currently, RIEInput :

* defaults its <input> size to 20, which limits visibility of entered text that's longer.
* only shows 20 characters when an RIEInput field is clicked on, to enter edit mode.

### Old behavior

![old](https://user-images.githubusercontent.com/887849/32146194-b04b0d1e-bcba-11e7-9ef0-00982c5c19a7.gif)

### New behavior

![new](https://user-images.githubusercontent.com/887849/32146197-bf345916-bcba-11e7-9348-9c61fc58f0e9.gif)

* Clicking to enter editable mode now opens `<input>` element with initial size adjusted to the existing text value.
* Size of `<input>` element now grows/shrinks as you type (min width is still defaulted to 20)

