### PR TITLE
Ability to add a wrapper element to tag items

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -19399,7 +19399,7 @@
 	        };
 
 	        _this.render = function () {
-	            debuf('render()');
+	            debug('render()');
 	            return _react2.default.createElement(
 	                'span',
 	                _extends({}, _this.props.defaultProps, { tabindex: '0', className: _this.makeClassString(), onClick: _this.elementClick }),
@@ -20059,7 +20059,7 @@
 	            _this.props.beforeFinish ? _this.props.beforeFinish() : null;
 	            var newValue = _reactDom2.default.findDOMNode(_this.refs.input).value;
 	            var result = _this.doValidations(newValue);
-	            if (result && _this.props.value !== newValue) {
+	            if (result && _this.props.value != newValue) {
 	                _this.commit(newValue);
 	            }
 	            if (!result && _this.props.handleValidationFail) {
@@ -20078,7 +20078,7 @@
 	        };
 
 	        _this.keyDown = function (event) {
-	            debug('keyDown(${event.keyCode})');
+	            debug('keyDown(' + event.keyCode + ')');
 	            if (event.keyCode === 13) {
 	                _this.finishEditing();
 	            } // Enter
@@ -20088,7 +20088,7 @@
 	        };
 
 	        _this.textChanged = function (event) {
-	            debug('textChanged(${event.target.value})');
+	            debug('textChanged(' + event.target.value + ')');
 	            _this.doValidations(event.target.value.trim());
 	        };
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -20416,11 +20416,17 @@
 	        _this.render = function () {
 	            return _react2.default.createElement(
 	                'div',
-	                { key: _this.props.text },
+	                {
+	                    key: _this.props.text,
+	                    className: _this.props.className
+	                },
 	                _this.props.text,
 	                _react2.default.createElement(
 	                    'div',
-	                    { onClick: _this.remove, className: _this.props.className || "remove" },
+	                    {
+	                        onClick: _this.remove,
+	                        className: _this.props.className + '-remove'
+	                    },
 	                    ' \xD7 '
 	                )
 	            );
@@ -20547,7 +20553,7 @@
 	        };
 
 	        _this2.makeTagElement = function (text) {
-	            return _react2.default.createElement(RIETag, { key: text, text: text, removeHandler: _this2.removeTag });
+	            return _react2.default.createElement(RIETag, { className: _this2.props.wrapperEditing, key: text, text: text, removeHandler: _this2.removeTag });
 	        };
 
 	        _this2.renderEditingComponent = function () {
@@ -20581,7 +20587,8 @@
 	    blurDelay: _propTypes2.default.number,
 	    placeholder: _propTypes2.default.string,
 	    wrapper: _propTypes2.default.string,
-	    wrapperClass: _propTypes2.default.string
+	    wrapperClass: _propTypes2.default.string,
+	    wrapperEditing: _propTypes2.default.string
 	};
 	exports.default = RIETags;
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -423,6 +423,8 @@
 	              placeholder: 'New',
 	              className: _this.state.highlight ? "tags editable" : "tags",
 	              classLoading: 'loading',
+	              wrapper: 'div',
+	              wrapperClass: 'tag-item',
 	              isDisabled: _this.state.isDisabled }),
 	            _this.state.showSource ? _react2.default.createElement(
 	              _reactHighlight2.default,
@@ -20503,16 +20505,45 @@
 	        };
 
 	        _this2.renderNormalComponent = function () {
-	            var tags = [].concat(_toConsumableArray(_this2.props.value)).join(_this2.props.separator || ", ");
-	            return _react2.default.createElement(
-	                'span',
-	                _extends({
-	                    tabIndex: '0',
-	                    className: _this2.makeClassString(),
-	                    onFocus: _this2.startEditing
-	                }, _this2.props.defaultProps),
-	                tags
-	            );
+	            if (_this2.props.wrapper) {
+	                var tags = [].concat(_toConsumableArray(_this2.props.value)).map(function (value, index) {
+	                    var wrapper = _react2.default.createElement(_this2.props.wrapper, {
+	                        key: index,
+	                        children: [value],
+	                        className: _this2.props.wrapperClass
+	                    });
+
+	                    return wrapper;
+	                });
+
+	                return _react2.default.createElement(
+	                    'span',
+	                    _extends({
+	                        tabIndex: '0',
+	                        className: _this2.makeClassString(),
+	                        onFocus: _this2.startEditing
+	                    }, _this2.props.defaultProps),
+	                    tags.reduce(function (result, el, index, arr) {
+	                        result.push(el);
+
+	                        if (index < arr.length - 1) result.push(_this2.props.separator || ', ');
+
+	                        return result;
+	                    }, [])
+	                );
+	            } else {
+	                var _tags = [].concat(_toConsumableArray(_this2.props.value)).join(_this2.props.separator || ', ');
+
+	                return _react2.default.createElement(
+	                    'span',
+	                    _extends({
+	                        tabIndex: '0',
+	                        className: _this2.makeClassString(),
+	                        onFocus: _this2.startEditing
+	                    }, _this2.props.defaultProps),
+	                    _tags
+	                );
+	            }
 	        };
 
 	        _this2.makeTagElement = function (text) {
@@ -20548,7 +20579,9 @@
 	    separator: _propTypes2.default.string,
 	    elementClass: _propTypes2.default.string,
 	    blurDelay: _propTypes2.default.number,
-	    placeholder: _propTypes2.default.string
+	    placeholder: _propTypes2.default.string,
+	    wrapper: _propTypes2.default.string,
+	    wrapperClass: _propTypes2.default.string
 	};
 	exports.default = RIETags;
 

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -247,6 +247,8 @@ isDisabled={this.state.isDisabled} />`}
           placeholder="New"
           className={this.state.highlight ? "tags editable" : "tags"}
           classLoading="loading"
+          wrapper="div"
+          wrapperClass="tag-item"
           isDisabled={this.state.isDisabled} />
         {this.state.showSource ? <Highlight className="jsx">
         {`<RIETags

--- a/src/RIEBase.js
+++ b/src/RIEBase.js
@@ -91,7 +91,7 @@ export default class RIEBase extends React.Component {
     };
 
     render = () => {
-        debuf(`render()`)
+        debug(`render()`)
         return <span {...this.props.defaultProps} tabindex="0" className={this.makeClassString()} onClick={this.elementClick}>{this.props.value}</span>;
     };
 }

--- a/src/RIEStatefulBase.js
+++ b/src/RIEStatefulBase.js
@@ -39,13 +39,13 @@ export default class RIEStatefulBase extends RIEBase {
     };
 
     keyDown = (event) => {
-        debug('keyDown(${event.keyCode})')
+        debug(`keyDown(${event.keyCode})`)
         if(event.keyCode === 13) { this.finishEditing() }           // Enter
         else if (event.keyCode === 27) { this.cancelEditing() }     // Escape
     };
 
     textChanged = (event) => {
-        debug('textChanged(${event.target.value})')
+        debug(`textChanged(${event.target.value})`)
         this.doValidations(event.target.value.trim());
     };
 

--- a/src/RIEStatefulBase.js
+++ b/src/RIEStatefulBase.js
@@ -22,7 +22,7 @@ export default class RIEStatefulBase extends RIEBase {
         this.props.beforeFinish ? this.props.beforeFinish() : null;
         let newValue = ReactDOM.findDOMNode(this.refs.input).value;
         const result = this.doValidations(newValue);
-        if(result && this.props.value !== newValue) {
+        if(result && this.props.value != newValue) {
             this.commit(newValue);
         }
         if(!result && this.props.handleValidationFail) {

--- a/src/RIETags.js
+++ b/src/RIETags.js
@@ -38,7 +38,9 @@ export default class RIETags extends RIEStatefulBase {
         separator: PropTypes.string,
         elementClass: PropTypes.string,
         blurDelay: PropTypes.number,
-        placeholder: PropTypes.string
+        placeholder: PropTypes.string,
+        wrapper: PropTypes.string,
+        wrapperClass: PropTypes.string,
     };
 
     addTag = (tag) => {
@@ -98,12 +100,44 @@ export default class RIETags extends RIEStatefulBase {
     };
 
     renderNormalComponent = () => {
-        let tags = [...this.props.value].join(this.props.separator || ", ");
-        return <span
-            tabIndex="0"
-            className={this.makeClassString()}
-            onFocus={this.startEditing}
-            {...this.props.defaultProps}>{tags}</span>;
+        if(this.props.wrapper) {
+            let tags = [...this.props.value].map((value, index) => {
+                const wrapper = React.createElement(this.props.wrapper, {
+                    key: index,
+                    children: [value],
+                    className: this.props.wrapperClass,
+                });
+
+                return wrapper;
+            });
+
+            return <span
+                tabIndex="0"
+                className={this.makeClassString()}
+                onFocus={this.startEditing}
+                {...this.props.defaultProps}
+            >{
+                tags.reduce((result, el, index, arr) => {
+                    result.push(el);
+
+                    if(index < arr.length - 1)
+                        result.push(this.props.separator || ', ');
+
+                    return result;
+                }, [])
+            }</span>;
+        }
+        else {
+            let tags = [...this.props.value].join(this.props.separator || ', ');
+
+            return <span
+                tabIndex="0"
+                className={this.makeClassString()}
+                onFocus={this.startEditing}
+                {...this.props.defaultProps}>
+                {tags}
+            </span>;
+        }
     };
 
     makeTagElement = (text) => {

--- a/src/RIETags.js
+++ b/src/RIETags.js
@@ -19,7 +19,16 @@ class RIETag extends React.Component {
     };
 
     render = () => {
-        return  <div key={this.props.text}>{this.props.text}<div onClick={this.remove} className={this.props.className || "remove"}> × </div></div>;
+        return  <div
+            key={this.props.text}
+            className={this.props.className}
+        >
+            {this.props.text}
+            <div
+                onClick={this.remove}
+                className={`${this.props.className}-remove`}
+            > × </div>
+        </div>;
     };
 }
 
@@ -41,6 +50,7 @@ export default class RIETags extends RIEStatefulBase {
         placeholder: PropTypes.string,
         wrapper: PropTypes.string,
         wrapperClass: PropTypes.string,
+        wrapperEditing: PropTypes.string,
     };
 
     addTag = (tag) => {
@@ -141,7 +151,7 @@ export default class RIETags extends RIEStatefulBase {
     };
 
     makeTagElement = (text) => {
-        return <RIETag key={text} text={text} removeHandler={this.removeTag} />;
+        return <RIETag className={this.props.wrapperEditing} key={text} text={text} removeHandler={this.removeTag} />;
     };
 
     renderEditingComponent = () => {


### PR DESCRIPTION
This makes the tag items easier to add custom styles, instead of only being able to describe the separator.

This also includes commits from #71 , so merging this will also be merging those as well.