### PR TITLE
Fixed typo debuf --> debug

### DIFF
--- a/src/RIEBase.js
+++ b/src/RIEBase.js
@@ -91,7 +91,7 @@ export default class RIEBase extends React.Component {
     };
 
     render = () => {
-        debuf(`render()`)
+        debug(`render()`)
         return <span {...this.props.defaultProps} tabindex="0" className={this.makeClassString()} onClick={this.elementClick}>{this.props.value}</span>;
     };
 }


### PR DESCRIPTION
This is a pretty straightforward fix.  The `debug` call was misspelled.  Changed `debuf` --> `debug`.
